### PR TITLE
Update lists/new returns only id

### DIFF
--- a/server/routes/lists.js
+++ b/server/routes/lists.js
@@ -51,9 +51,9 @@ router.post("/lists/new", verifyToken, function(req, res) {
 				} else {
 					foundUser.my_lists.push(createdList);
 					foundUser.save();
+					res.status(200).send({list_id: createdList._id});
 				}
 			});
-			res.redirect("/lists");
 		}
 	});
 });


### PR DESCRIPTION
No issue. Updated lists/new. It returns only the new list's id. Because it would be easier for @ChianHuei to get just one id instead of traversing the whole array of list ids.